### PR TITLE
Add Python 2 compatibility

### DIFF
--- a/cmake_setuptools/cmake/__init__.py
+++ b/cmake_setuptools/cmake/__init__.py
@@ -1,11 +1,14 @@
+from __future__ import division, print_function
+
 import os
 import subprocess
-import shutil
 import sys
+
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
+from shutilwhich import which
 
-CMAKE_EXE = os.environ.get('CMAKE_EXE', shutil.which('cmake'))
+CMAKE_EXE = os.environ.get('CMAKE_EXE', which('cmake'))
 
 
 def check_for_cmake():
@@ -22,6 +25,7 @@ class CMakeExtension(Extension):
 
     def __init__(self, name, sourcedir=''):
         check_for_cmake()
+        # not using super() for Python 2 compatibility
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 
@@ -59,7 +63,8 @@ class CMakeBuildExt(build_ext):
                                   env=env)
             print()
         else:
-            super().build_extension(ext)
+            # not using super() for Python 2 compatibility
+            build_ext.build_extension(self, ext)
 
 
 __all__ = ['CMakeBuildExt', 'CMakeExtension']

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
+import io
 from setuptools import setup, find_packages
 from cmake_setuptools import __version__
 
-with open('README.md', encoding='utf-8') as f:
+with io.open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='cmake_setuptools',
@@ -11,7 +12,7 @@ setup(name='cmake_setuptools',
       author='Ray Douglass',
       url='https://github.com/raydouglass/cmake_setuptools',
       version=__version__,
-      install_requires=['setuptools'],
+      install_requires=['setuptools', 'shutilwhich'],
       license="Apache 2.0",
       packages=find_packages(),
       classifiers=[


### PR DESCRIPTION
Some very minor adjustments to make the library work with Python 2.

I understand that Python 2 is going EOL in January, but there are still places where using Python 2 can't be avoided. Such as the Robotic Operating System (ROS 1) in my case, unfortunately. :crying_cat_face: 