### PR TITLE
 cmake  compatible get_ext_filename (to enable --inplace setup)

### DIFF
--- a/cmake_setuptools/cmake/__init__.py
+++ b/cmake_setuptools/cmake/__init__.py
@@ -31,7 +31,18 @@ class CMakeBuildExt(build_ext):
     setuptools build_exit which builds using cmake & make
     You can add cmake args with the CMAKE_COMMON_VARIABLES environment variable
     """
-
+    
+    def get_ext_filename(self, ext_name):
+        r"""Convert the name of an extension (eg. "foo.bar") into the name
+        of the file from which it will be loaded (eg. "foo/bar.so", or
+        "foo\bar.pyd").
+        """
+        from distutils.sysconfig import get_config_var
+        ext_path = ext_name.split('.')
+        ext_suffix = get_config_var('EXT_SUFFIX')
+        ext_suffix = "."+ext_suffix.split('.')[-1]
+        return os.path.join(*ext_path) + ext_suffix
+    
     def build_extension(self, ext):
         check_for_cmake()
         if isinstance(ext, CMakeExtension):


### PR DESCRIPTION
 cmake compatible get_ext_filename to fix `--inplace` setup.