### PR TITLE
Update __init__.py

### DIFF
--- a/cmake_setuptools/cmake/__init__.py
+++ b/cmake_setuptools/cmake/__init__.py
@@ -54,7 +54,7 @@ class CMakeBuildExt(build_ext):
             subprocess.check_call(cmake_args,
                                   cwd=self.build_temp,
                                   env=env)
-            subprocess.check_call(['make', '-j', ext.name],
+            subprocess.check_call(['make', '-j'],
                                   cwd=self.build_temp,
                                   env=env)
             print()


### PR DESCRIPTION
Removed 'ext.name' from make target. It is unlikely that CMakeLists.txt would contain targets that are not required by the python package for which the extension is being built. This way we don't run into installation problems.